### PR TITLE
Remove space_cache=v2 mount option

### DIFF
--- a/etc/calamares/modules/mount.conf
+++ b/etc/calamares/modules/mount.conf
@@ -50,7 +50,7 @@ mountOptions:
     - filesystem: efi
       options: [ defaults, umask=0077 ]
     - filesystem: btrfs
-      options: [ defaults, noatime, compress=zstd, space_cache=v2, commit=120 ]
+      options: [ defaults, noatime, compress=zstd, commit=120 ]
     - filesystem: btrfs_swap
       options: [ defaults, noatime ]
     - filesystem: ext4

--- a/usr/lib/calamares/modules/mount/mount.conf
+++ b/usr/lib/calamares/modules/mount/mount.conf
@@ -50,7 +50,7 @@ mountOptions:
     - filesystem: efi
       options: [ defaults, umask=0077 ]
     - filesystem: btrfs
-      options: [ defaults, noatime, compress=zstd, space_cache=v2, commit=120 ]
+      options: [ defaults, noatime, compress=zstd, commit=120 ]
     - filesystem: btrfs_swap
       options: [ defaults, noatime ]
     - filesystem: ext4


### PR DESCRIPTION
It's default now and therefore not needed.